### PR TITLE
Fix GLB model collisions

### DIFF
--- a/src/components/Furniture.js
+++ b/src/components/Furniture.js
@@ -32,7 +32,6 @@ export class Furniture {
                     path: '/models/White_Pebble_Vase_0802124528_texture.glb',
                     name: 'White Pebble Vase',
                     scale: 0.5,
-                    height: 0.3,
                     probability: 0.7 // Back to 70% chance to spawn
                 }
                 // Add more models here as they become available
@@ -47,7 +46,6 @@ export class Furniture {
                             name: config.name,
                             model: model,
                             scale: config.scale,
-                            height: config.height,
                             probability: config.probability
                         });
                     }
@@ -142,18 +140,22 @@ export class Furniture {
             // Use probability to determine if this model should be spawned
             if (Math.random() < modelData.probability) {
                 const modelInstance = modelData.model.clone();
-                
+
+                // Apply scale before calculating bounds
+                modelInstance.scale.multiplyScalar(modelData.scale);
+
+                // Compute bounding box to determine correct height placement
+                const bbox = new THREE.Box3().setFromObject(modelInstance);
+                const size = bbox.getSize(new THREE.Vector3());
+
                 // Set random position within the room boundaries
                 const halfRoom = (this.roomSize - 1) / 2;
                 modelInstance.position.x = Math.random() * (this.roomSize - 1) - halfRoom;
                 modelInstance.position.z = Math.random() * (this.roomSize - 1) - halfRoom;
-                
-                // Place the model on the floor
-                modelInstance.position.y = modelData.height / 2;
-                
-                // Apply scale
-                modelInstance.scale.multiplyScalar(modelData.scale);
-                
+
+                // Place the model on the floor based on its actual height
+                modelInstance.position.y = size.y / 2;
+
                 // Add to the furniture group
                 this.group.add(modelInstance);
             }

--- a/src/components/SceneManager.js
+++ b/src/components/SceneManager.js
@@ -185,9 +185,22 @@ export default class SceneManager {
             for (const target of collisionTargets) {
                 const targetBBox = new THREE.Box3().setFromObject(target);
                 const tempBBox = selectedObjectBBox.clone();
-                tempBBox.translate(new THREE.Vector3(intersectionPoint.x - this.selectedObject.position.x, 0, intersectionPoint.z - this.selectedObject.position.z));
-                if (tempBBox.intersectsBox(targetBBox)) {
-                    const targetTopY = target.position.y + (targetBBox.getSize(this.tempVector).y / 2);
+                tempBBox.translate(new THREE.Vector3(
+                    intersectionPoint.x - this.selectedObject.position.x,
+                    0,
+                    intersectionPoint.z - this.selectedObject.position.z
+                ));
+
+                // Check overlap only in the XZ plane to detect stacking regardless of height
+                const intersectsXZ =
+                    tempBBox.min.x < targetBBox.max.x &&
+                    tempBBox.max.x > targetBBox.min.x &&
+                    tempBBox.min.z < targetBBox.max.z &&
+                    tempBBox.max.z > targetBBox.min.z;
+
+                if (intersectsXZ) {
+                    const targetTopY =
+                        target.position.y + targetBBox.getSize(this.tempVector).y / 2;
                     if (targetTopY > highestY) {
                         highestY = targetTopY;
                     }


### PR DESCRIPTION
## Summary
- Correctly compute GLB object floor placement using bounding box height
- Detect collisions using XZ overlap so stacked objects rest properly

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68957be52c5c8325af850562431a9eda